### PR TITLE
Add upload vendor directory task

### DIFF
--- a/lib/hem/tasks/rsync/deps.rb
+++ b/lib/hem/tasks/rsync/deps.rb
@@ -88,8 +88,20 @@ namespace :deps do
         from_path: 'vendor/',
         to_path: 'vendor',
         deciding_file_path: File.join('vendor', 'autoload.php'),
-        guest_to_host_allowed: false
+        host_to_guest_allowed: false
       )
+    end
+
+    desc 'Upload the vendor directory from the host to the guest'
+    task :vendor_directory_to_guest do
+      Hem.ui.title 'Uploading vendor directory changes to guest'
+
+      Rake::Task['vm:rsync_manual'].execute(
+        from_path: 'vendor/',
+        to_path: 'vendor'
+      )
+
+      Hem.ui.success('Uploaded vendor directory changes to guest')
     end
 
     desc 'Reload the VM to use NFS mounts per directory, or sync rsync mounts if already enabled'

--- a/lib/hem/tasks/rsync/version.rb
+++ b/lib/hem/tasks/rsync/version.rb
@@ -1,7 +1,7 @@
 module Hem
   module Tasks
     module Rsync
-      VERSION = '1.3.0'.freeze
+      VERSION = '2.0.0'.freeze
     end
   end
 end

--- a/lib/hem/tasks/rsync/vm.rb
+++ b/lib/hem/tasks/rsync/vm.rb
@@ -86,7 +86,7 @@ namespace :vm do
   argument :from_path
   argument :to_path
   argument :deciding_file_path
-  argument :guest_to_host_allowed, optional: true, default: true
+  argument :host_to_guest_allowed, optional: true, default: true
   task :sync_guest_changes do |_task_name, args|
     Hem.ui.title "Determining if #{args[:deciding_file_path]} is newer on the host or guest"
 
@@ -108,7 +108,7 @@ namespace :vm do
         to_path: to_path,
         is_reverse: true
       )
-    elsif args[:guest_to_host_allowed] && local_file_modified.to_i > remote_file_modified.to_i
+    elsif args[:host_to_guest_allowed] && local_file_modified.to_i > remote_file_modified.to_i
       Hem.ui.success("Host file #{args[:deciding_file_path]} is newer, syncing to guest")
       from_path = File.join(Hem.project_path, args[:to_path])
       to_path = File.join(Hem.project_config.vm.project_mount_path, args[:from_path])
@@ -117,7 +117,7 @@ namespace :vm do
         from_path: from_path,
         to_path: to_path
       )
-    elsif !args[:guest_to_host_allowed]
+    elsif !args[:host_to_guest_allowed]
       Hem.ui.success('Host is more up to date than the guest but syncing via another method')
     else
       Hem.ui.success("Host and guest file #{args[:deciding_file_path]} are up to date, not doing anything")


### PR DESCRIPTION
- New task that has name parity with `deps:sync:vendor_directory_from_guest`
- Fix naming of variable as it didn't make sense.
- Bump version 2.x as this counts as BC
