### PR TITLE
MISC: chown the vagrant folder, to avoid permissions issues

### DIFF
--- a/lib/hem/tasks/rsync/version.rb
+++ b/lib/hem/tasks/rsync/version.rb
@@ -1,7 +1,7 @@
 module Hem
   module Tasks
     module Rsync
-      VERSION = '2.0.0'.freeze
+      VERSION = '2.1.0'.freeze
     end
   end
 end

--- a/lib/hem/tasks/rsync/vm.rb
+++ b/lib/hem/tasks/rsync/vm.rb
@@ -28,6 +28,8 @@ namespace :vm do
 
     next unless files
 
+    run "sudo chown apache:vagrant '#{Hem.project_config.vm.project_mount_path}'", realtime: true
+
     rsync_command = <<-COMMAND
       find '.' -type f -maxdepth 1 -print0 | \
       rsync --files-from=- --from0 --human-readable --progress \


### PR DESCRIPTION
Avoids permissions issues when syncing the root files up.

Was previously handled with a bash script triggered by vagrant, but we removed it recently to get around an XDebug issue.

Sample of the issue:

```
  rsync: mkstemp "/vagrant/..editorconfig.ehRxMU" failed: Permission denied (13)
  rsync: mkstemp "/vagrant/..gitignore.L5LOcN" failed: Permission denied (13)
  rsync: mkstemp "/vagrant/..htaccess.yx3AGF" failed: Permission denied (13)
  rsync: mkstemp "/vagrant/..htaccess.sample.B6AQay" failed: Permission denied (13)
```
