### PR TITLE
Add composer preload task.

### DIFF
--- a/lib/hem/tasks/rsync/deps.rb
+++ b/lib/hem/tasks/rsync/deps.rb
@@ -3,6 +3,7 @@
 
 before 'deps:composer', 'deps:sync:composer_files_to_guest'
 after 'deps:composer', 'deps:sync:reload_or_sync'
+after 'deps:composer', 'deps:composer_preload'
 
 namespace :deps do
   desc 'Update composer dependencies'
@@ -50,6 +51,13 @@ namespace :deps do
     end
 
     Hem.ui.separator
+  end
+
+  desc 'Preload the composer files into file system cache'
+  task :composer_preload do
+    Hem.ui.title 'Composer PHP files loading into file system cache'
+    run 'find vendor -type f -name "*.php" -exec cat {} > /dev/null +', realtime: true
+    Hem.ui.success 'Composer PHP files loaded into file system cache'
   end
 
   desc 'Syncing dependencies to/from the VM'

--- a/lib/hem/tasks/rsync/version.rb
+++ b/lib/hem/tasks/rsync/version.rb
@@ -1,7 +1,7 @@
 module Hem
   module Tasks
     module Rsync
-      VERSION = '2.1.1'.freeze
+      VERSION = '2.2.0'.freeze
     end
   end
 end


### PR DESCRIPTION
As vendor is synced via rsync and not over NFS, we can load the vendor files into
the filesystem cache memory to give a speed boost.

For magento2, the first hit to magento is 8 to 10 seconds instead of 17.
