### PR TITLE
Trigger vendor preload after vm start

### DIFF
--- a/lib/hem/tasks/rsync/deps.rb
+++ b/lib/hem/tasks/rsync/deps.rb
@@ -3,6 +3,9 @@
 
 before 'deps:composer', 'deps:sync:composer_files_to_guest'
 after 'deps:composer', 'deps:sync:reload_or_sync'
+
+after 'vm:reload', 'deps:composer_preload'
+after 'vm:start', 'deps:composer_preload'
 after 'deps:composer', 'deps:composer_preload'
 
 namespace :deps do
@@ -56,7 +59,7 @@ namespace :deps do
   desc 'Preload the composer files into file system cache'
   task :composer_preload do
     Hem.ui.title 'Composer PHP files loading into file system cache'
-    run 'find vendor -type f -name "*.php" -exec cat {} > /dev/null +', realtime: true
+    run 'if [ -e vendor ]; then find vendor -type f -name "*.php" -exec cat {} > /dev/null + ; fi', realtime: true
     Hem.ui.success 'Composer PHP files loaded into file system cache'
   end
 

--- a/lib/hem/tasks/rsync/version.rb
+++ b/lib/hem/tasks/rsync/version.rb
@@ -1,7 +1,7 @@
 module Hem
   module Tasks
     module Rsync
-      VERSION = '2.2.0'.freeze
+      VERSION = '2.3.0'.freeze
     end
   end
 end


### PR DESCRIPTION
Running after deps:composer will only give the speed boost whilst the VM is up.

When turned off and on, the performance will be back to normal.

So, run after each time the VM starts as well.
